### PR TITLE
feat(graph): denormalisation + selectors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,9 @@
     "browser": true,
     "jasmine": true
   },
-  "globals": {},
+  "globals": {
+    "jest": true
+  },
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"

--- a/src/actions/link.actions.js
+++ b/src/actions/link.actions.js
@@ -73,7 +73,7 @@ export const removeLinkAttribute = (linkId, attributesKey) => ({
  * @param {string} linkId
  * @return {Object}
  */
-export const removeLink = (linkId) => ({
+export const removeLink = linkId => ({
 	type: FLOWDESIGNER_LINK_REMOVE,
 	linkId,
 });

--- a/src/actions/link.actions.test.js
+++ b/src/actions/link.actions.test.js
@@ -10,119 +10,119 @@ const mockStore = configureMockStore(middlewares);
 
 describe('Check that link action creators generate proper' +
 	' action objects and perform checking', () => {
-		it('addLink', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_LINK_ADD',
-				linkId: 'linkId',
-				sourceId: 'sourceId',
-				targetId: 'targetId',
-				linkType: 'linkType',
-				attributes: { selected: true },
-			}];
+	it('addLink', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_LINK_ADD',
+			linkId: 'linkId',
+			sourceId: 'sourceId',
+			targetId: 'targetId',
+			linkType: 'linkType',
+			attributes: { selected: true },
+		}];
 
-			const store = mockStore({
-				flowDesigner: {
-					links: new Map(),
-					ports: new Map({
-						id1: { id: 'portId', portType: 'type' },
-						id2: { id: 'portId', portType: 'type' },
-					}),
-				},
-			});
+		const store = mockStore({
+			flowDesigner: {
+				links: new Map(),
+				ports: new Map({
+					id1: { id: 'portId', portType: 'type' },
+					id2: { id: 'portId', portType: 'type' },
+				}),
+			},
+		});
 
-			store.dispatch(
+		store.dispatch(
 				linkActions.addLink('linkId', 'sourceId', 'targetId', 'linkType', { selected: true })
 			);
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('setLinkTarget', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_LINK_SET_TARGET',
-				linkId: 'linkId',
-				targetId: 'portId',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					links: new Map({ linkId: { id: 'linkId' } }),
-					ports: new Map({ id1: { id: 'portId', portType: 'type' } }),
-				},
-			});
-
-			store.dispatch(linkActions.setLinkTarget('linkId', 'portId'));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('setLinkSource', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_LINK_SET_SOURCE',
-				linkId: 'linkId',
-				sourceId: 'portId',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					links: new Map({ linkId: { id: 'linkId' } }),
-					ports: new Map({ id1: { id: 'portId', portType: 'type' } }),
-				},
-			});
-
-			store.dispatch(linkActions.setLinkSource('linkId', 'portId'));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('setLinkAttribute', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_LINK_SET_ATTR',
-				linkId: 'id',
-				attributes: { selected: true },
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					links: new Map({ id: { id: 'linkId', linkType: 'type' } }),
-				},
-			});
-
-			store.dispatch(linkActions.setLinkAttribute('id', { selected: true }));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('removeLinkAttribute', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_LINK_REMOVE_ATTR',
-				linkId: 'id',
-				attributesKey: 'selected',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					links: new Map({ id: { id: 'linkId', linkType: 'type' } }),
-				},
-			});
-
-			store.dispatch(linkActions.removeLinkAttribute('id', 'selected'));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('removeLink', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_LINK_REMOVE',
-				linkId: 'id',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					links: new Map({ id: { id: 'linkId' } }),
-				},
-			});
-
-			store.dispatch(linkActions.removeLink('id'));
-			expect(store.getActions()).toEqual(expectedActions);
-		});
+		expect(store.getActions()).toEqual(expectedActions);
 	});
+
+	it('setLinkTarget', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_LINK_SET_TARGET',
+			linkId: 'linkId',
+			targetId: 'portId',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				links: new Map({ linkId: { id: 'linkId' } }),
+				ports: new Map({ id1: { id: 'portId', portType: 'type' } }),
+			},
+		});
+
+		store.dispatch(linkActions.setLinkTarget('linkId', 'portId'));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('setLinkSource', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_LINK_SET_SOURCE',
+			linkId: 'linkId',
+			sourceId: 'portId',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				links: new Map({ linkId: { id: 'linkId' } }),
+				ports: new Map({ id1: { id: 'portId', portType: 'type' } }),
+			},
+		});
+
+		store.dispatch(linkActions.setLinkSource('linkId', 'portId'));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('setLinkAttribute', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_LINK_SET_ATTR',
+			linkId: 'id',
+			attributes: { selected: true },
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				links: new Map({ id: { id: 'linkId', linkType: 'type' } }),
+			},
+		});
+
+		store.dispatch(linkActions.setLinkAttribute('id', { selected: true }));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('removeLinkAttribute', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_LINK_REMOVE_ATTR',
+			linkId: 'id',
+			attributesKey: 'selected',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				links: new Map({ id: { id: 'linkId', linkType: 'type' } }),
+			},
+		});
+
+		store.dispatch(linkActions.removeLinkAttribute('id', 'selected'));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('removeLink', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_LINK_REMOVE',
+			linkId: 'id',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				links: new Map({ id: { id: 'linkId' } }),
+			},
+		});
+
+		store.dispatch(linkActions.removeLink('id'));
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+});

--- a/src/actions/node.actions.test.js
+++ b/src/actions/node.actions.test.js
@@ -11,120 +11,120 @@ const mockStore = configureMockStore(middlewares);
 
 describe('Check that node action creators generate proper' +
 	' action objects and perform checking', () => {
-		it('addNode generate action with 0 configuration', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_NODE_ADD',
-				nodeId: 'id',
-				nodePosition: { x: 75, y: 75 },
-				nodeSize: { width: 50, heigth: 50 },
-				nodeType: 'nodeType',
-				attributes: {},
-			}];
+	it('addNode generate action with 0 configuration', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_NODE_ADD',
+			nodeId: 'id',
+			nodePosition: { x: 75, y: 75 },
+			nodeSize: { width: 50, heigth: 50 },
+			nodeType: 'nodeType',
+			attributes: {},
+		}];
 
-			const store = mockStore({
-				flowDesigner: {
-					nodes: new Map({}),
-				},
-			});
+		const store = mockStore({
+			flowDesigner: {
+				nodes: new Map({}),
+			},
+		});
 
-			store.dispatch(
+		store.dispatch(
 				nodeActions.addNode('id', { x: 75, y: 75 }, { width: 50, heigth: 50 }, 'nodeType', {})
 			);
 
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('moveNode generate a proper action object witch nodeId and nodePosition parameter', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_NODE_MOVE',
-				nodeId: 'nodeId',
-				nodePosition: { x: 10, y: 20 },
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					nodes: new Map({ nodeId: { id: 'nodeId', nodeType: 'type' } }),
-					nodeTypes: new Map({
-						type: new Map({
-							component: { calculatePortPosition: () => ({}) },
-						}),
-					}),
-					ports: new OrderedMap(),
-				},
-			});
-
-			store.dispatch(nodeActions.moveNodeTo('nodeId', { x: 10, y: 20 }, {}));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('setNodeSize', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_NODE_SET_SIZE',
-				nodeId: 'nodeId',
-				nodeSize: { width: 100, height: 100 },
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					nodes: new Map({ nodeId: { id: 'nodeId', nodeType: 'type' } }),
-				},
-			});
-
-			store.dispatch(nodeActions.setNodeSize('nodeId', { width: 100, height: 100 }));
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('setNodeAttribute', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_NODE_SET_ATTR',
-				nodeId: 'id',
-				attributes: { selected: true },
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					nodes: new Map({ id: { id: 'nodeId', nodeType: 'type' } }),
-				},
-			});
-
-			store.dispatch(nodeActions.setNodeAttribute('id', { selected: true }));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('removeNodeAttribute', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_NODE_REMOVE_ATTR',
-				nodeId: 'id',
-				attributesKey: 'selected',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					nodes: new Map({ id: { id: 'nodeId', nodeType: 'type' } }),
-				},
-			});
-
-			store.dispatch(nodeActions.removeNodeAttribute('id', 'selected'));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('removeNode', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_NODE_REMOVE',
-				nodeId: 'id',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					nodes: new Map({ id: { id: 'nodeId', nodeType: 'type' } }),
-				},
-			});
-
-			store.dispatch(nodeActions.removeNode('id'));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
+		expect(store.getActions()).toEqual(expectedActions);
 	});
+
+	it('moveNode generate a proper action object witch nodeId and nodePosition parameter', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_NODE_MOVE',
+			nodeId: 'nodeId',
+			nodePosition: { x: 10, y: 20 },
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				nodes: new Map({ nodeId: { id: 'nodeId', nodeType: 'type' } }),
+				nodeTypes: new Map({
+					type: new Map({
+						component: { calculatePortPosition: () => ({}) },
+					}),
+				}),
+				ports: new OrderedMap(),
+			},
+		});
+
+		store.dispatch(nodeActions.moveNodeTo('nodeId', { x: 10, y: 20 }, {}));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('setNodeSize', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_NODE_SET_SIZE',
+			nodeId: 'nodeId',
+			nodeSize: { width: 100, height: 100 },
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				nodes: new Map({ nodeId: { id: 'nodeId', nodeType: 'type' } }),
+			},
+		});
+
+		store.dispatch(nodeActions.setNodeSize('nodeId', { width: 100, height: 100 }));
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('setNodeAttribute', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_NODE_SET_ATTR',
+			nodeId: 'id',
+			attributes: { selected: true },
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				nodes: new Map({ id: { id: 'nodeId', nodeType: 'type' } }),
+			},
+		});
+
+		store.dispatch(nodeActions.setNodeAttribute('id', { selected: true }));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('removeNodeAttribute', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_NODE_REMOVE_ATTR',
+			nodeId: 'id',
+			attributesKey: 'selected',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				nodes: new Map({ id: { id: 'nodeId', nodeType: 'type' } }),
+			},
+		});
+
+		store.dispatch(nodeActions.removeNodeAttribute('id', 'selected'));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('removeNode', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_NODE_REMOVE',
+			nodeId: 'id',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				nodes: new Map({ id: { id: 'nodeId', nodeType: 'type' } }),
+			},
+		});
+
+		store.dispatch(nodeActions.removeNode('id'));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+});

--- a/src/actions/nodeType.actions.js
+++ b/src/actions/nodeType.actions.js
@@ -4,7 +4,7 @@ import { FLOWDESIGNER_NODETYPE_SET } from '../constants/flowdesigner.constants';
  * Ask to set a map for nodeTypes
  * @param {Map<String, Object>} nodeTypes
  */
-export const setNodeTypes = (nodeTypes) => ({
+export const setNodeTypes = nodeTypes => ({
 	type: FLOWDESIGNER_NODETYPE_SET,
 	nodeTypes,
 });

--- a/src/actions/port.actions.test.js
+++ b/src/actions/port.actions.test.js
@@ -10,76 +10,76 @@ const mockStore = configureMockStore(middlewares);
 
 describe('Check that port action creators generate proper' +
 	' action objects and perform checking', () => {
-		it('addPort', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_PORT_ADD',
-				nodeId: 'nodeId',
-				portId: 'portId',
-				portType: 'portType',
-				attributes: { selected: true },
-			}];
+	it('addPort', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_PORT_ADD',
+			nodeId: 'nodeId',
+			portId: 'portId',
+			portType: 'portType',
+			attributes: { selected: true },
+		}];
 
-			const store = mockStore({
-				flowDesigner: {
-					nodes: new Map({ nodeId: { id: 'nodeId', nodeType: 'type' } }),
-					ports: new Map(),
-				},
-			});
-
-			store.dispatch(portActions.addPort('nodeId', 'portId', 'portType', { selected: true }));
-			expect(store.getActions()).toEqual(expectedActions);
+		const store = mockStore({
+			flowDesigner: {
+				nodes: new Map({ nodeId: { id: 'nodeId', nodeType: 'type' } }),
+				ports: new Map(),
+			},
 		});
 
-
-		it('setPortAttribute', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_PORT_SET_ATTR',
-				portId: 'id',
-				attributes: { selected: true },
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					ports: new Map({ id: { id: 'portId', portType: 'type' } }),
-				},
-			});
-
-			store.dispatch(portActions.setPortAttribute('id', { selected: true }));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('removePortAttribute', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_PORT_REMOVE_ATTR',
-				portId: 'id',
-				attributesKey: 'selected',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					ports: new Map({ id: { id: 'portId' } }),
-				},
-			});
-
-			store.dispatch(portActions.removePortAttribute('id', 'selected'));
-
-			expect(store.getActions()).toEqual(expectedActions);
-		});
-
-		it('removePort', () => {
-			const expectedActions = [{
-				type: 'FLOWDESIGNER_PORT_REMOVE',
-				portId: 'portId',
-			}];
-
-			const store = mockStore({
-				flowDesigner: {
-					ports: new Map({ portId: { id: 'portId' } }),
-				},
-			});
-
-			store.dispatch(portActions.removePort('portId'));
-			expect(store.getActions()).toEqual(expectedActions);
-		});
+		store.dispatch(portActions.addPort('nodeId', 'portId', 'portType', { selected: true }));
+		expect(store.getActions()).toEqual(expectedActions);
 	});
+
+
+	it('setPortAttribute', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_PORT_SET_ATTR',
+			portId: 'id',
+			attributes: { selected: true },
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				ports: new Map({ id: { id: 'portId', portType: 'type' } }),
+			},
+		});
+
+		store.dispatch(portActions.setPortAttribute('id', { selected: true }));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('removePortAttribute', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_PORT_REMOVE_ATTR',
+			portId: 'id',
+			attributesKey: 'selected',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				ports: new Map({ id: { id: 'portId' } }),
+			},
+		});
+
+		store.dispatch(portActions.removePortAttribute('id', 'selected'));
+
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+
+	it('removePort', () => {
+		const expectedActions = [{
+			type: 'FLOWDESIGNER_PORT_REMOVE',
+			portId: 'portId',
+		}];
+
+		const store = mockStore({
+			flowDesigner: {
+				ports: new Map({ portId: { id: 'portId' } }),
+			},
+		});
+
+		store.dispatch(portActions.removePort('portId'));
+		expect(store.getActions()).toEqual(expectedActions);
+	});
+});

--- a/src/reducers/__snapshots__/flow.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/flow.reducer.test.js.snap
@@ -1,10 +1,28 @@
-exports[`FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation should batch many elements creation 1`] = `Object {}`;
+exports[`FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation should batch many elements creation 1`] = `
+Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
+  "nodes": Object {},
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
 
 exports[`FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation should batch one element creation 1`] = `
 Object {
   "in": Object {
     "nodeId": Object {},
   },
+  "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "nodeId": Object {
       "attributes": Object {},
@@ -23,11 +41,35 @@ Object {
   "out": Object {
     "nodeId": Object {},
   },
+  "ports": Object {},
   "preds": Object {
     "nodeId": Object {},
   },
   "sucs": Object {
     "nodeId": Object {},
+  },
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
+
+exports[`FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation should handle throwing sub reducer by returning old state 1`] = `
+Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
+  "nodes": Object {},
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
   },
 }
 `;

--- a/src/reducers/__snapshots__/flow.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/flow.reducer.test.js.snap
@@ -1,0 +1,51 @@
+exports[`FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation should batch many elements creation 1`] = `Object {}`;
+
+exports[`FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation should batch one element creation 1`] = `
+Object {
+  "in": Object {
+    "nodeId": Object {},
+  },
+  "nodes": Object {
+    "nodeId": Object {
+      "attributes": Object {},
+      "id": "nodeId",
+      "nodeSize": Object {
+        "height": 10,
+        "width": 10,
+      },
+      "nodeType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+  "out": Object {
+    "nodeId": Object {},
+  },
+  "preds": Object {
+    "nodeId": Object {},
+  },
+  "sucs": Object {
+    "nodeId": Object {},
+  },
+}
+`;
+
+exports[`FLOWDESIGNER_FLOW_LOAD should reset old flow state and load news not touching flow config should load elements 1`] = `
+Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
+  "nodes": Object {},
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
+}
+`;

--- a/src/reducers/__snapshots__/link.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/link.reducer.test.js.snap
@@ -1,0 +1,405 @@
+exports[`check linkreducer FLOWDESIGNER_LINK_ADD should add a new link to the state 1`] = `
+Object {
+  "in": Object {
+    "id2": Object {
+      "id2": Object {
+        "id2": "id2",
+      },
+    },
+  },
+  "links": Object {
+    "id1": Object {
+      "attributes": Object {
+        "attr": "attr",
+      },
+      "id": "id1",
+      "linkType": undefined,
+      "sourceId": "id1",
+      "targetId": "id2",
+    },
+    "id2": Object {
+      "attributes": Object {},
+      "id": "id2",
+      "linkType": undefined,
+      "sourceId": "id1",
+      "targetId": "id2",
+    },
+  },
+  "nodes": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+  },
+  "out": Object {
+    "id1": Object {
+      "id1": Object {
+        "id2": "id2",
+      },
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id4": Object {
+      "attributes": undefined,
+      "id": "id4",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+  },
+  "preds": Object {
+    "id2": Object {
+      "id1": "id1",
+    },
+  },
+  "sucs": Object {
+    "id1": Object {
+      "id2": "id2",
+    },
+  },
+}
+`;
+
+exports[`check linkreducer FLOWDESIGNER_LINK_REMOVE should remove link from state 1`] = `
+Object {
+  "links": Object {},
+  "nodes": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id4": Object {
+      "attributes": undefined,
+      "id": "id4",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+  },
+}
+`;
+
+exports[`check linkreducer FLOWDESIGNER_LINK_REMOVE_ATTR should remove a specific attributes from attr map 1`] = `
+Object {
+  "links": Object {
+    "id1": Object {
+      "attributes": Object {},
+      "id": "id1",
+      "linkType": undefined,
+      "sourceId": "id1",
+      "targetId": "id2",
+    },
+  },
+  "nodes": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id4": Object {
+      "attributes": undefined,
+      "id": "id4",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+  },
+}
+`;
+
+exports[`check linkreducer FLOWDESIGNER_LINK_SET_ATTR should merge attributes within link attr property 1`] = `
+Object {
+  "links": Object {
+    "id1": Object {
+      "attributes": Object {
+        "attr": "attr",
+        "selected": false,
+      },
+      "id": "id1",
+      "linkType": undefined,
+      "sourceId": "id1",
+      "targetId": "id2",
+    },
+  },
+  "nodes": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id4": Object {
+      "attributes": undefined,
+      "id": "id4",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+  },
+}
+`;
+
+exports[`check linkreducer FLOWDESIGNER_LINK_SET_SOURCE switch source to correct port if it exist 1`] = `
+Object {
+  "links": Object {
+    "id1": Object {
+      "attributes": Object {
+        "attr": "attr",
+      },
+      "id": "id1",
+      "linkType": undefined,
+      "sourceId": "id4",
+      "targetId": "id2",
+    },
+  },
+  "nodes": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+  },
+  "out": Object {
+    "id1": Object {
+      "id4": Object {
+        "id1": "id1",
+      },
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id4": Object {
+      "attributes": undefined,
+      "id": "id4",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+  },
+}
+`;
+
+exports[`check linkreducer FLOWDESIGNER_LINK_SET_TARGET switch target to correct port if it exist 1`] = `
+Object {
+  "in": Object {
+    "id2": Object {
+      "id3": Object {
+        "id1": "id1",
+      },
+    },
+  },
+  "links": Object {
+    "id1": Object {
+      "attributes": Object {
+        "attr": "attr",
+      },
+      "id": "id1",
+      "linkType": undefined,
+      "sourceId": "id1",
+      "targetId": "id3",
+    },
+  },
+  "nodes": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": undefined,
+      "position": undefined,
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": undefined,
+      "id": "id1",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": "id2",
+      "portType": undefined,
+      "position": undefined,
+    },
+    "id4": Object {
+      "attributes": undefined,
+      "id": "id4",
+      "nodeId": "id1",
+      "portType": undefined,
+      "position": undefined,
+    },
+  },
+}
+`;

--- a/src/reducers/__snapshots__/link.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/link.reducer.test.js.snap
@@ -25,6 +25,7 @@ Object {
       "targetId": "id2",
     },
   },
+  "nodeTypes": Object {},
   "nodes": Object {
     "id1": Object {
       "attributes": undefined,
@@ -88,12 +89,19 @@ Object {
       "id2": "id2",
     },
   },
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`check linkreducer FLOWDESIGNER_LINK_REMOVE should remove link from state 1`] = `
 Object {
+  "in": Object {},
   "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "id1": Object {
       "attributes": undefined,
@@ -110,6 +118,7 @@ Object {
       "position": undefined,
     },
   },
+  "out": Object {},
   "ports": Object {
     "id1": Object {
       "attributes": undefined,
@@ -140,11 +149,19 @@ Object {
       "position": undefined,
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`check linkreducer FLOWDESIGNER_LINK_REMOVE_ATTR should remove a specific attributes from attr map 1`] = `
 Object {
+  "in": Object {},
   "links": Object {
     "id1": Object {
       "attributes": Object {},
@@ -154,6 +171,7 @@ Object {
       "targetId": "id2",
     },
   },
+  "nodeTypes": Object {},
   "nodes": Object {
     "id1": Object {
       "attributes": undefined,
@@ -170,6 +188,7 @@ Object {
       "position": undefined,
     },
   },
+  "out": Object {},
   "ports": Object {
     "id1": Object {
       "attributes": undefined,
@@ -200,11 +219,19 @@ Object {
       "position": undefined,
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`check linkreducer FLOWDESIGNER_LINK_SET_ATTR should merge attributes within link attr property 1`] = `
 Object {
+  "in": Object {},
   "links": Object {
     "id1": Object {
       "attributes": Object {
@@ -217,6 +244,7 @@ Object {
       "targetId": "id2",
     },
   },
+  "nodeTypes": Object {},
   "nodes": Object {
     "id1": Object {
       "attributes": undefined,
@@ -233,6 +261,7 @@ Object {
       "position": undefined,
     },
   },
+  "out": Object {},
   "ports": Object {
     "id1": Object {
       "attributes": undefined,
@@ -263,11 +292,19 @@ Object {
       "position": undefined,
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`check linkreducer FLOWDESIGNER_LINK_SET_SOURCE switch source to correct port if it exist 1`] = `
 Object {
+  "in": Object {},
   "links": Object {
     "id1": Object {
       "attributes": Object {
@@ -279,6 +316,7 @@ Object {
       "targetId": "id2",
     },
   },
+  "nodeTypes": Object {},
   "nodes": Object {
     "id1": Object {
       "attributes": undefined,
@@ -332,6 +370,13 @@ Object {
       "position": undefined,
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
@@ -355,6 +400,7 @@ Object {
       "targetId": "id3",
     },
   },
+  "nodeTypes": Object {},
   "nodes": Object {
     "id1": Object {
       "attributes": undefined,
@@ -371,6 +417,7 @@ Object {
       "position": undefined,
     },
   },
+  "out": Object {},
   "ports": Object {
     "id1": Object {
       "attributes": undefined,
@@ -400,6 +447,13 @@ Object {
       "portType": undefined,
       "position": undefined,
     },
+  },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
   },
 }
 `;

--- a/src/reducers/__snapshots__/node.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/node.reducer.test.js.snap
@@ -3,6 +3,8 @@ Object {
   "in": Object {
     "id": Object {},
   },
+  "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "id": Object {
       "attributes": Object {
@@ -23,11 +25,17 @@ Object {
   "out": Object {
     "id": Object {},
   },
+  "ports": Object {},
   "preds": Object {
     "id": Object {},
   },
   "sucs": Object {
     "id": Object {},
+  },
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
   },
 }
 `;
@@ -37,6 +45,8 @@ Object {
   "in": Object {
     "id": Object {},
   },
+  "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "id": Object {
       "attributes": Object {},
@@ -55,17 +65,69 @@ Object {
   "out": Object {
     "id": Object {},
   },
+  "ports": Object {},
   "preds": Object {
     "id": Object {},
   },
   "sucs": Object {
     "id": Object {},
   },
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
+
+exports[`Check node reducer FLOWDESIGNER_NODE_MOVE update node position 1`] = `
+Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
+  "nodes": Object {
+    "id1": Object {
+      "attributes": Object {
+        "selected": true,
+      },
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": "type1",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": Object {
+        "selected": false,
+      },
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": "type2",
+      "position": Object {
+        "x": 50,
+        "y": 50,
+      },
+    },
+  },
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`Check node reducer FLOWDESIGNER_NODE_REMOVE should remove node from node collection 1`] = `
 Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "id2": Object {
       "attributes": Object {
@@ -79,6 +141,145 @@ Object {
         "y": 10,
       },
     },
+  },
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
+
+exports[`Check node reducer FLOWDESIGNER_NODE_REMOVE_ATTR should add attribute to node attribute map 1`] = `
+Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
+  "nodes": Object {
+    "id1": Object {
+      "attributes": Object {},
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": "type1",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": Object {
+        "selected": false,
+      },
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": "type2",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
+
+exports[`Check node reducer FLOWDESIGNER_NODE_SET_ATTR should add attribute to node attribute map 1`] = `
+Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
+  "nodes": Object {
+    "id1": Object {
+      "attributes": Object {
+        "selected": false,
+      },
+      "id": "id1",
+      "nodeSize": undefined,
+      "nodeType": "type1",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": Object {
+        "selected": false,
+      },
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": "type2",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
+
+exports[`Check node reducer FLOWDESIGNER_NODE_SET_SIZE update node size property 1`] = `
+Object {
+  "in": Object {},
+  "links": Object {},
+  "nodeTypes": Object {},
+  "nodes": Object {
+    "id1": Object {
+      "attributes": Object {
+        "selected": true,
+      },
+      "id": "id1",
+      "nodeSize": Object {
+        "height": 200,
+        "width": 200,
+      },
+      "nodeType": "type1",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": Object {
+        "selected": false,
+      },
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": "type2",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+  "out": Object {},
+  "ports": Object {},
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
   },
 }
 `;

--- a/src/reducers/__snapshots__/node.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/node.reducer.test.js.snap
@@ -1,0 +1,84 @@
+exports[`Check node reducer FLOWDESIGNER_NODE_ADD add a new node to the node collection with the right type 1`] = `
+Object {
+  "in": Object {
+    "id": Object {},
+  },
+  "nodes": Object {
+    "id": Object {
+      "attributes": Object {
+        "name": "test",
+      },
+      "id": "id",
+      "nodeSize": Object {
+        "height": undefined,
+        "width": undefined,
+      },
+      "nodeType": "MY_NODE_TYPE",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+  "out": Object {
+    "id": Object {},
+  },
+  "preds": Object {
+    "id": Object {},
+  },
+  "sucs": Object {
+    "id": Object {},
+  },
+}
+`;
+
+exports[`Check node reducer FLOWDESIGNER_NODE_ADD properly add a new node to the node collection 1`] = `
+Object {
+  "in": Object {
+    "id": Object {},
+  },
+  "nodes": Object {
+    "id": Object {
+      "attributes": Object {},
+      "id": "id",
+      "nodeSize": Object {
+        "height": undefined,
+        "width": undefined,
+      },
+      "nodeType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+  "out": Object {
+    "id": Object {},
+  },
+  "preds": Object {
+    "id": Object {},
+  },
+  "sucs": Object {
+    "id": Object {},
+  },
+}
+`;
+
+exports[`Check node reducer FLOWDESIGNER_NODE_REMOVE should remove node from node collection 1`] = `
+Object {
+  "nodes": Object {
+    "id2": Object {
+      "attributes": Object {
+        "selected": false,
+      },
+      "id": "id2",
+      "nodeSize": undefined,
+      "nodeType": "type2",
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+}
+`;

--- a/src/reducers/__snapshots__/port.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/port.reducer.test.js.snap
@@ -1,0 +1,244 @@
+exports[`Check port reducer FLOWDESIGNER_PORT_ADD properly add the port to the port OrderedMap 1`] = `
+Object {
+  "links": Object {},
+  "nodes": Object {
+    "nodeId": Object {},
+  },
+  "out": Object {
+    "nodeId": Object {
+      "portId": Object {},
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": Object {
+        "attr": "attr",
+      },
+      "id": "id1",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "portId": Object {
+      "attributes": Object {
+        "clicked": true,
+        "type": "EMITTER",
+      },
+      "id": "portId",
+      "nodeId": "nodeId",
+      "portType": "portType",
+      "position": undefined,
+    },
+  },
+}
+`;
+
+exports[`Check port reducer FLOWDESIGNER_PORT_ADDS to add multiple ports to port collection 1`] = `
+Object {
+  "in": Object {
+    "nodeId": Object {
+      "portId2": Object {},
+    },
+  },
+  "links": Object {},
+  "nodes": Object {
+    "nodeId": Object {},
+  },
+  "out": Object {
+    "nodeId": Object {
+      "portId1": Object {},
+    },
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": Object {
+        "attr": "attr",
+      },
+      "id": "id1",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "portId1": Object {
+      "attributes": Object {
+        "type": "EMITTER",
+      },
+      "id": "portId1",
+      "nodeId": "nodeId",
+      "portType": "portType",
+      "position": undefined,
+    },
+    "portId2": Object {
+      "attributes": Object {
+        "type": "SINK",
+      },
+      "id": "portId2",
+      "nodeId": "nodeId",
+      "portType": "portType",
+      "position": undefined,
+    },
+  },
+}
+`;
+
+exports[`Check port reducer FLOWDESIGNER_PORT_REMOVE should remove port from ports collection 1`] = `
+Object {
+  "links": Object {},
+  "nodes": Object {
+    "nodeId": Object {},
+  },
+  "ports": Object {
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+}
+`;
+
+exports[`Check port reducer FLOWDESIGNER_PORT_REMOVE_ATTR to remove attr from attr map 1`] = `
+Object {
+  "links": Object {},
+  "nodes": Object {
+    "nodeId": Object {},
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": Object {},
+      "id": "id1",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+}
+`;
+
+exports[`Check port reducer FLOWDESIGNER_PORT_SET_ATTR to merge a new attributes in attribute collection 1`] = `
+Object {
+  "links": Object {},
+  "nodes": Object {
+    "nodeId": Object {},
+  },
+  "ports": Object {
+    "id1": Object {
+      "attributes": Object {
+        "attr": "attr",
+        "selected": true,
+      },
+      "id": "id1",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id2": Object {
+      "attributes": undefined,
+      "id": "id2",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+    "id3": Object {
+      "attributes": undefined,
+      "id": "id3",
+      "nodeId": undefined,
+      "portType": undefined,
+      "position": Object {
+        "x": 10,
+        "y": 10,
+      },
+    },
+  },
+}
+`;

--- a/src/reducers/__snapshots__/port.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/port.reducer.test.js.snap
@@ -1,6 +1,8 @@
 exports[`Check port reducer FLOWDESIGNER_PORT_ADD properly add the port to the port OrderedMap 1`] = `
 Object {
+  "in": Object {},
   "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "nodeId": Object {},
   },
@@ -53,6 +55,13 @@ Object {
       "position": undefined,
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
@@ -64,6 +73,7 @@ Object {
     },
   },
   "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "nodeId": Object {},
   },
@@ -124,15 +134,25 @@ Object {
       "position": undefined,
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`Check port reducer FLOWDESIGNER_PORT_REMOVE should remove port from ports collection 1`] = `
 Object {
+  "in": Object {},
   "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "nodeId": Object {},
   },
+  "out": Object {},
   "ports": Object {
     "id2": Object {
       "attributes": undefined,
@@ -155,15 +175,25 @@ Object {
       },
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`Check port reducer FLOWDESIGNER_PORT_REMOVE_ATTR to remove attr from attr map 1`] = `
 Object {
+  "in": Object {},
   "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "nodeId": Object {},
   },
+  "out": Object {},
   "ports": Object {
     "id1": Object {
       "attributes": Object {},
@@ -196,15 +226,25 @@ Object {
       },
     },
   },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
+  },
 }
 `;
 
 exports[`Check port reducer FLOWDESIGNER_PORT_SET_ATTR to merge a new attributes in attribute collection 1`] = `
 Object {
+  "in": Object {},
   "links": Object {},
+  "nodeTypes": Object {},
   "nodes": Object {
     "nodeId": Object {},
   },
+  "out": Object {},
   "ports": Object {
     "id1": Object {
       "attributes": Object {
@@ -239,6 +279,13 @@ Object {
         "y": 10,
       },
     },
+  },
+  "preds": Object {},
+  "sucs": Object {},
+  "transform": Object {
+    "k": 1,
+    "x": 0,
+    "y": 0,
   },
 }
 `;

--- a/src/reducers/flow.reducer.js
+++ b/src/reducers/flow.reducer.js
@@ -17,6 +17,10 @@ const defaultState = new Map({
 	nodes: new Map(),
 	links: new Map(),
 	ports: new OrderedMap(),
+	out: new Map(),
+	in: new Map(),
+	sucs: new Map(),
+	preds: new Map(),
 	nodeTypes: new Map(),
 	transform: { k: 1, x: 0, y: 0 },
 });

--- a/src/reducers/flow.reducer.js
+++ b/src/reducers/flow.reducer.js
@@ -11,7 +11,7 @@ import linksReducer from './link.reducer';
 import portsReducer from './port.reducer';
 import nodeTypeReducer from './nodeType.reducer';
 
-const defaultState = new Map({
+export const defaultState = new Map({
 	nodes: new Map(),
 	links: new Map(),
 	ports: new OrderedMap(),

--- a/src/reducers/flow.reducer.js
+++ b/src/reducers/flow.reducer.js
@@ -102,8 +102,6 @@ export const calculatePortsPosition = (state, action) => {
 	return state;
 };
 
-
-
 const flowDesignerReducer = (state, action) => {
 	let newState = reducer(state, action);
 	newState = calculatePortsPosition(newState, action, state);

--- a/src/reducers/flow.reducer.js
+++ b/src/reducers/flow.reducer.js
@@ -10,8 +10,6 @@ import nodesReducer from './node.reducer';
 import linksReducer from './link.reducer';
 import portsReducer from './port.reducer';
 import nodeTypeReducer from './nodeType.reducer';
-import { getDetachedPorts } from '../selectors/portSelectors';
-import { getDetachedLinks } from '../selectors/linkSelectors';
 
 const defaultState = new Map({
 	nodes: new Map(),
@@ -104,50 +102,10 @@ export const calculatePortsPosition = (state, action) => {
 	return state;
 };
 
-/**
- * if any port parent node does not exist, the port will be destroyed
- *
- * @params {object} state react-flow-designer state
- *
- * @return {object} new state
- */
-const destroyDetachedPorts = (state) => {
-	const detachedPorts = getDetachedPorts(state);
-	let newState = state;
-	detachedPorts.forEach(port => {
-		newState = reducer(newState, {
-			type: 'FLOWDESIGNER_PORT_REMOVE',
-			portId: port.id,
-		});
-	});
-	return newState;
-};
 
-/**
- * if any link is not attached to two ports, it will be destroyed
- *
- * @params {object} state react-flow-designer state
- *
-* @return {object} new state
- */
-const destroyDetachedLinks = (state) => {
-	const detachedLinks = getDetachedLinks(state);
-	let newState = state;
-	detachedLinks.forEach(link => {
-		newState = reducer(newState, {
-			type: 'FLOWDESIGNER_LINK_REMOVE',
-			linkId: link.id,
-		});
-	});
-	return newState;
-};
 
 const flowDesignerReducer = (state, action) => {
 	let newState = reducer(state, action);
-	if (action.type !== 'FLOWDESIGNER_NODE_MOVE') {
-		newState = destroyDetachedPorts(newState, action, state);
-		newState = destroyDetachedLinks(newState, action, state);
-	}
 	newState = calculatePortsPosition(newState, action, state);
 	return newState;
 };

--- a/src/reducers/flow.reducer.test.js
+++ b/src/reducers/flow.reducer.test.js
@@ -23,22 +23,7 @@ describe('FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation', () => {
 					{}
 				),
 			],
-		})).toEqual(new Map()
-			.set('nodes', new Map()
-				.set('nodeId', new NodeRecord({
-					id: 'nodeId',
-					position: new PositionRecord({
-						x: 10,
-						y: 10,
-					}),
-					nodeSize: new SizeRecord({
-						height: 10,
-						width: 10,
-					}),
-					nodeType: undefined,
-					attributes: new Map(),
-				}))
-			));
+		})).toMatchSnapshot();
 	});
 
 	it('should batch many elements creation', () => {
@@ -66,43 +51,7 @@ describe('FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation', () => {
 					{},
 				),
 			],
-		})).toEqual(new Map()
-			.set('nodes', new Map()
-				.set('nodeId', new NodeRecord({
-					id: 'nodeId',
-					position: new PositionRecord({
-						x: 10,
-						y: 10,
-					}),
-					nodeSize: new SizeRecord({
-						height: 10,
-						width: 10,
-					}),
-					nodeType: undefined,
-					attributes: new Map(),
-				}))
-				.set('node2', new NodeRecord({
-					id: 'node2',
-					position: new PositionRecord({
-						x: 10,
-						y: 10,
-					}),
-					nodeSize: new SizeRecord({
-						height: 10,
-						width: 10,
-					}),
-					nodeType: undefined,
-					attributes: new Map(),
-				}))
-			).set('ports', new Map()
-				.set('portId', new PortRecord({
-					id: 'portId',
-					nodeId: 'nodeId',
-					portType: undefined,
-					position: undefined,
-					attributes: new Map(),
-				})))
-			);
+		})).toMatchSnapshot();
 	});
 
 	it('should handle throwing sub reducer by returning old state', () => {
@@ -136,75 +85,41 @@ describe('FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation', () => {
 
 describe('FLOWDESIGNER_FLOW_LOAD should reset old flow state and load news not touching flow config', () => {
 	it('should load elements', () => {
-		expect(reducer(new Map({ nports: new Map(), links: new Map(), ports: new Map(), nodeTypes: new Map() }), {
-			type: 'FLOWDESIGNER.FLOW_LOAD',
-			listOfActionCreation: [
-				nodeActions.addNode(
+		expect(reducer(new Map({
+			nodes: new Map(),
+			links: new Map(),
+			ports: new Map(),
+			out: new Map(),
+			in: new Map(),
+			sucs: new Map(),
+			preds: new Map(),
+			nodeTypes: new Map(),
+			transform: { k: 1, x: 0, y: 0 } }),
+			{
+				type: 'FLOWDESIGNER.FLOW_LOAD',
+				listOfActionCreation: [
+					nodeActions.addNode(
 					'nodeId',
 					{ x: 10, y: 10 },
 					{ height: 10, width: 10 },
 					undefined,
 					{}
 				),
-				nodeActions.addNode(
+					nodeActions.addNode(
 					'node2',
 					{ x: 10, y: 10 },
 					{ height: 10, width: 10 },
 					undefined,
 					{}
 				),
-				portActions.addPort(
+					portActions.addPort(
 					'nodeId',
 					'portId',
 					undefined,
 					{},
 				),
-			],
-		})).toEqual(new Map()
-			.set('nodes', new Map()
-				.set('nodeId', new NodeRecord({
-					id: 'nodeId',
-					position: new PositionRecord({
-						x: 10,
-						y: 10,
-					}),
-					nodeSize: new SizeRecord({
-						height: 10,
-						width: 10,
-					}),
-					nodeType: undefined,
-					attributes: new Map(),
-				}))
-				.set('node2', new NodeRecord({
-					id: 'node2',
-					position: new PositionRecord({
-						x: 10,
-						y: 10,
-					}),
-					nodeSize: new SizeRecord({
-						height: 10,
-						width: 10,
-					}),
-					nodeType: undefined,
-					attributes: new Map(),
-				}))
-			).set('links', new Map())
-			.set('ports', new OrderedMap()
-				.set('portId', new PortRecord({
-					id: 'portId',
-					nodeId: 'nodeId',
-					portType: undefined,
-					position: undefined,
-					attributes: new Map(),
-				}))
-			)
-			.set('nodeTypes', new Map())
-			.set('transform', {
-				k: 1,
-				x: 0,
-				y: 0,
-			})
-			);
+				],
+			})).toMatchSnapshot();
 	});
 });
 

--- a/src/reducers/flow.reducer.test.js
+++ b/src/reducers/flow.reducer.test.js
@@ -1,6 +1,6 @@
 import { Map, OrderedMap } from 'immutable';
 
-import { reducer, calculatePortsPosition } from './flow.reducer';
+import { reducer, calculatePortsPosition, defaultState } from './flow.reducer';
 import * as nodeActions from '../actions/node.actions';
 import * as portActions from '../actions/port.actions';
 import {
@@ -12,7 +12,7 @@ import {
 
 describe('FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation', () => {
 	it('should batch one element creation', () => {
-		expect(reducer(new Map(), {
+		expect(reducer(defaultState, {
 			type: 'FLOWDESIGNER.FLOW_ADD_ELEMENTS',
 			listOfActionCreation: [
 				nodeActions.addNode(
@@ -27,7 +27,7 @@ describe('FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation', () => {
 	});
 
 	it('should batch many elements creation', () => {
-		expect(reducer(new Map(), {
+		expect(reducer(defaultState, {
 			type: 'FLOWDESIGNER.FLOW_ADD_ELEMENTS',
 			listOfActionCreation: [
 				nodeActions.addNode(
@@ -55,7 +55,7 @@ describe('FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation', () => {
 	});
 
 	it('should handle throwing sub reducer by returning old state', () => {
-		expect(reducer(new Map(), {
+		expect(reducer(defaultState, {
 			type: 'FLOWDESIGNER.FLOW_ADD_ELEMENTS',
 			listOfActionCreation: [
 				nodeActions.addNode(
@@ -79,45 +79,36 @@ describe('FLOWDESIGNER_FLOW_ADD_ELEMENTS is batching elements creation', () => {
 					{},
 				),
 			],
-		})).toEqual(new Map());
+		})).toMatchSnapshot();
 	});
 });
 
 describe('FLOWDESIGNER_FLOW_LOAD should reset old flow state and load news not touching flow config', () => {
 	it('should load elements', () => {
-		expect(reducer(new Map({
-			nodes: new Map(),
-			links: new Map(),
-			ports: new Map(),
-			out: new Map(),
-			in: new Map(),
-			sucs: new Map(),
-			preds: new Map(),
-			nodeTypes: new Map(),
-			transform: { k: 1, x: 0, y: 0 } }),
+		expect(reducer(defaultState,
 			{
 				type: 'FLOWDESIGNER.FLOW_LOAD',
 				listOfActionCreation: [
 					nodeActions.addNode(
-					'nodeId',
-					{ x: 10, y: 10 },
-					{ height: 10, width: 10 },
-					undefined,
-					{}
-				),
+						'nodeId',
+						{ x: 10, y: 10 },
+						{ height: 10, width: 10 },
+						undefined,
+						{}
+					),
 					nodeActions.addNode(
-					'node2',
-					{ x: 10, y: 10 },
-					{ height: 10, width: 10 },
-					undefined,
-					{}
-				),
+						'node2',
+						{ x: 10, y: 10 },
+						{ height: 10, width: 10 },
+						undefined,
+						{}
+					),
 					portActions.addPort(
-					'nodeId',
-					'portId',
-					undefined,
-					{},
-				),
+						'nodeId',
+						'portId',
+						undefined,
+						{},
+					),
 				],
 			})).toMatchSnapshot();
 	});
@@ -125,7 +116,7 @@ describe('FLOWDESIGNER_FLOW_LOAD should reset old flow state and load news not t
 
 
 describe('calculatePortsPosition behavior', () => {
-	const state = new Map()
+	const state = defaultState
 		.set('nodes', new Map()
 			.set('42', new NodeRecord({
 				id: '42',

--- a/src/reducers/flow.reducer.test.js
+++ b/src/reducers/flow.reducer.test.js
@@ -1,4 +1,4 @@
-import { Map, OrderedMap } from 'immutable';
+import { Map } from 'immutable';
 
 import { reducer, calculatePortsPosition, defaultState } from './flow.reducer';
 import * as nodeActions from '../actions/node.actions';

--- a/src/reducers/link.reducer.js
+++ b/src/reducers/link.reducer.js
@@ -14,82 +14,130 @@ import { LinkRecord } from '../constants/flowdesigner.model';
 
 const defaultState = new Map();
 
+/**
+ * Delete link information in (In and Out) cache
+ * @params state
+ * @params action
+ */
+function tryDeleteLinkCache(state, action) {
+	let newState = state;
+	if (state.getIn(['links', action.linkId])) {
+		if (state.getIn(['ports', state.getIn(['links', action.linkId]).targetId])) {
+			newState = newState.deleteIn([
+				'in',
+				state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId,
+				state.getIn(['links', action.linkId]).targetId,
+				action.linkId,
+			]);
+		}
+		if (state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId])) {
+			newState = newState.deleteIn([
+				'out',
+				state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId,
+				state.getIn(['links', action.linkId]).sourceId,
+				action.linkId,
+			]);
+		}
+		if (state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]) && state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId])){
+			newState = newState.deleteIn([
+				'sucs',
+				state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId,
+				state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId,
+			])
+			.deleteIn([
+				'preds',
+				state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId,
+				state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId,
+			]);
+		}
+	}
+	return newState;
+}
+
 export default function linkReducer(state = defaultState, action) {
 	switch (action.type) {
-		case FLOWDESIGNER_LINK_ADD:
-			if (state.getIn(['links', action.linkId])) {
-				invariant(
+	case FLOWDESIGNER_LINK_ADD:
+		if (state.getIn(['links', action.linkId])) {
+			invariant(
 					false,
 					`can't create a link ${action.linkId} when it already exist`);
-			}
-			if (!state.getIn(['ports', action.targetId])) {
-				invariant(
+		}
+		if (!state.getIn(['ports', action.targetId])) {
+			invariant(
 					false,
 					`can't set a non existing target with id ${action.targetId} on link ${action.linkId}`
 				);
-			}
-			if (!state.getIn(['ports', action.sourceId])) {
-				invariant(
+		}
+		if (!state.getIn(['ports', action.sourceId])) {
+			invariant(
 					false,
 					`can't set a non existing source with id ${action.sourceId} on link ${action.linkId}`
 				);
-			}
-			return state.setIn(['links', action.linkId], new LinkRecord({
-				id: action.linkId,
-				sourceId: action.sourceId,
-				targetId: action.targetId,
-				linkType: action.linkType,
-				attributes: new Map(action.attributes),
-			}));
-		case FLOWDESIGNER_LINK_SET_TARGET:
-			if (!state.getIn(['links', action.linkId])) {
-				invariant(
+		}
+		return state.setIn(['links', action.linkId], new LinkRecord({
+			id: action.linkId,
+			sourceId: action.sourceId,
+			targetId: action.targetId,
+			linkType: action.linkType,
+			attributes: new Map(action.attributes),
+		}))
+		.setIn(['sucs', state.getIn(['ports', action.sourceId]).nodeId, state.getIn(['ports', action.targetId]).nodeId], state.getIn(['ports', action.targetId]).nodeId)
+		.setIn(['preds', state.getIn(['ports', action.targetId]).nodeId, state.getIn(['ports', action.sourceId]).nodeId], state.getIn(['ports', action.sourceId]).nodeId)
+		.setIn(['out', state.getIn(['ports', action.sourceId]).nodeId, action.sourceId, action.linkId], action.linkId)
+		.setIn(['in', state.getIn(['ports', action.targetId]).nodeId, action.targetId, action.linkId], action.linkId);
+	case FLOWDESIGNER_LINK_SET_TARGET:
+		if (!state.getIn(['links', action.linkId])) {
+			invariant(
 					false,
 					`can't set a target ${action.targetId} on non existing link with id ${action.linkId}`);
-			}
-			if (!state.getIn(['ports', action.targetId])) {
-				invariant(
+		}
+		if (!state.getIn(['ports', action.targetId])) {
+			invariant(
 					false,
 					`can't set a non existing target with id ${action.targetId} on link ${action.linkId}`
 				);
-			}
-			return state.setIn(['links', action.linkId, 'targetId'], action.targetId);
-		case FLOWDESIGNER_LINK_SET_SOURCE:
-			if (!state.getIn(['links', action.linkId])) {
-				invariant(
+		}
+		return state.setIn(['links', action.linkId, 'targetId'], action.targetId)
+		.deleteIn(['in', state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId, state.getIn(['links', action.linkId]).targetId, action.linkId])
+		.setIn(['in', state.getIn(['ports', action.targetId]).nodeId, action.targetId, action.linkId], action.linkId);
+	case FLOWDESIGNER_LINK_SET_SOURCE:
+		if (!state.getIn(['links', action.linkId])) {
+			invariant(
 					false,
 					`can't set a source ${action.sourceId} on non existing link with id ${action.linkId}`
 				);
-			}
-			if (!state.getIn(['ports', action.sourceId])) {
-				invariant(
+		}
+		if (!state.getIn(['ports', action.sourceId])) {
+			invariant(
 					false,
 					`can't set a non existing target with id ${action.sourceId} on link ${action.linkId}`
 				);
-			}
-			return state.setIn(['links', action.linkId, 'sourceId'], action.sourceId);
-		case FLOWDESIGNER_LINK_REMOVE:
-			if (!state.getIn(['links', action.linkId])) {
-				invariant(
+		}
+		return state.setIn(['links', action.linkId, 'sourceId'], action.sourceId)
+		.deleteIn(['out', state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId, state.getIn(['links', action.linkId]).sourceId, action.linkId])
+		.setIn(['out', state.getIn(['ports', action.sourceId]).nodeId, action.sourceId, action.linkId], action.linkId);
+	case FLOWDESIGNER_LINK_REMOVE:
+		if (!state.getIn(['links', action.linkId])) {
+			invariant(
 					false,
 					`can't remove non existing link ${action.linkId}`);
-			}
-			return state.deleteIn(['links', action.linkId]);
-		case FLOWDESIGNER_LINK_SET_ATTR:
-			if (!state.getIn(['links', action.linkId])) {
-				invariant(
+		}
+		return tryDeleteLinkCache(state, action).deleteIn(['links', action.linkId]);
+	case FLOWDESIGNER_LINK_SET_ATTR:
+		if (!state.getIn(['links', action.linkId])) {
+			invariant(
 					false,
 					`Can't set an attribute on non existing link ${action.linkId}`);
-			}
-			return state.mergeIn(['links', action.linkId, 'attributes'], new Map(action.attributes));
-		case FLOWDESIGNER_LINK_REMOVE_ATTR:
-			if (!state.getIn(['links', action.linkId])) {
-				invariant(
+		}
+		return state.mergeIn(['links', action.linkId, 'attributes'], new Map(action.attributes));
+	case FLOWDESIGNER_LINK_REMOVE_ATTR:
+		if (!state.getIn(['links', action.linkId])) {
+			invariant(
 					false,
 					`Can't remove an attribute on non existing link ${action.linkId}`);
-			}
-			return state.deleteIn(['links', action.linkId, 'attributes', action.attributesKey]);
-		default:
-			return state;
+		}
+		return state.deleteIn(['links', action.linkId, 'attributes', action.attributesKey]);
+	default:
+		return state;
 	}
 }

--- a/src/reducers/link.reducer.test.js
+++ b/src/reducers/link.reducer.test.js
@@ -1,10 +1,11 @@
 import { Map } from 'immutable';
 
+import { defaultState } from './flow.reducer';
 import linkReducer from './link.reducer';
 import { LinkRecord, PortRecord, NodeRecord } from '../constants/flowdesigner.model';
 
 describe('check linkreducer', () => {
-	const initialState = new Map()
+	const initialState = defaultState
 		.set('nodes', new Map()
 			.set('id1', new NodeRecord({
 				id: 'id1',

--- a/src/reducers/link.reducer.test.js
+++ b/src/reducers/link.reducer.test.js
@@ -1,21 +1,41 @@
 import { Map } from 'immutable';
 
 import linkReducer from './link.reducer';
-import { LinkRecord, PortRecord } from '../constants/flowdesigner.model';
+import { LinkRecord, PortRecord, NodeRecord } from '../constants/flowdesigner.model';
 
 describe('check linkreducer', () => {
 	const initialState = new Map()
+		.set('nodes', new Map()
+			.set('id1', new NodeRecord({
+				id: 'id1',
+			}))
+			.set('id2', new NodeRecord({
+				id: 'id2',
+			}))
+		)
 		.set('links', new Map()
 			.set('id1', new LinkRecord({
 				id: 'id1',
+				sourceId: 'id1',
+				targetId: 'id2',
 				attributes: new Map().set('attr', 'attr'),
 			}))
 		).set('ports', new Map()
 			.set('id1', new PortRecord({
 				id: 'id1',
+				nodeId: 'id1',
 			}))
 			.set('id2', new PortRecord({
 				id: 'id2',
+				nodeId: 'id2',
+			}))
+			.set('id3', new PortRecord({
+				id: 'id3',
+				nodeId: 'id2',
+			}))
+			.set('id4', new PortRecord({
+				id: 'id4',
+				nodeId: 'id1',
 			}))
 		);
 
@@ -25,81 +45,25 @@ describe('check linkreducer', () => {
 			linkId: 'id2',
 			sourceId: 'id1',
 			targetId: 'id2',
-		})).toEqual(new Map()
-			.set('links', new Map()
-				.set('id1', new LinkRecord({
-					id: 'id1',
-					attributes: new Map().set('attr', 'attr'),
-				}))
-				.set('id2', new LinkRecord({
-					id: 'id2',
-					sourceId: 'id1',
-					targetId: 'id2',
-					attributes: new Map(),
-				}))
-			).set('ports', new Map()
-				.set('id1', new PortRecord({
-					id: 'id1',
-				}))
-				.set('id2', new PortRecord({
-					id: 'id2',
-				}))
-			));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_LINK_REMOVE should remove link from state', () => {
 		expect(linkReducer(initialState, { type: 'FLOWDESIGNER_LINK_REMOVE', linkId: 'id1' }))
-			.toEqual(new Map()
-				.set('links', new Map())
-				.set('ports', new Map()
-					.set('id1', new PortRecord({
-						id: 'id1',
-					}))
-					.set('id2', new PortRecord({
-						id: 'id2',
-					}))
-				));
+			.toMatchSnapshot();
 	});
 
 
 	it('FLOWDESIGNER_LINK_SET_TARGET switch target to correct port if it exist', () => {
 		expect(linkReducer(initialState,
-			{ type: 'FLOWDESIGNER_LINK_SET_TARGET', linkId: 'id1', targetId: 'id1' }
-		)).toEqual(new Map()
-			.set('links', new Map()
-				.set('id1', new LinkRecord({
-					id: 'id1',
-					targetId: 'id1',
-					attributes: new Map().set('attr', 'attr'),
-				}))
-			).set('ports', new Map()
-				.set('id1', new PortRecord({
-					id: 'id1',
-				}))
-				.set('id2', new PortRecord({
-					id: 'id2',
-				}))
-			));
+			{ type: 'FLOWDESIGNER_LINK_SET_TARGET', linkId: 'id1', targetId: 'id3' }
+		)).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_LINK_SET_SOURCE switch source to correct port if it exist', () => {
 		expect(linkReducer(initialState,
-			{ type: 'FLOWDESIGNER_LINK_SET_SOURCE', linkId: 'id1', sourceId: 'id1' }
-		)).toEqual(new Map()
-			.set('links', new Map()
-				.set('id1', new LinkRecord({
-					id: 'id1',
-					sourceId: 'id1',
-					attributes: new Map().set('attr', 'attr'),
-				}))
-			).set('ports', new Map()
-				.set('id1', new PortRecord({
-					id: 'id1',
-				}))
-				.set('id2', new PortRecord({
-					id: 'id2',
-				}))
-			));
+			{ type: 'FLOWDESIGNER_LINK_SET_SOURCE', linkId: 'id1', sourceId: 'id4' }
+		)).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_LINK_SET_ATTR should merge attributes within link attr property', () => {
@@ -107,40 +71,14 @@ describe('check linkreducer', () => {
 			type: 'FLOWDESIGNER_LINK_SET_ATTR',
 			linkId: 'id1',
 			attributes: { selected: false },
-		})).toEqual(new Map()
-			.set('links', new Map()
-				.set('id1', new LinkRecord({
-					id: 'id1',
-					attributes: new Map().set('attr', 'attr').set('selected', false),
-				}))
-			).set('ports', new Map()
-				.set('id1', new PortRecord({
-					id: 'id1',
-				}))
-				.set('id2', new PortRecord({
-					id: 'id2',
-				}))
-			));
-	});
+		})).toMatchSnapshot()
+;	});
 
 	it('FLOWDESIGNER_LINK_REMOVE_ATTR should remove a specific attributes from attr map', () => {
 		expect(linkReducer(initialState, {
 			type: 'FLOWDESIGNER_LINK_REMOVE_ATTR',
 			linkId: 'id1',
 			attributesKey: 'attr',
-		})).toEqual(new Map()
-			.set('links', new Map()
-				.set('id1', new LinkRecord({
-					id: 'id1',
-					attributes: new Map(),
-				}))
-			).set('ports', new Map()
-				.set('id1', new PortRecord({
-					id: 'id1',
-				}))
-				.set('id2', new PortRecord({
-					id: 'id2',
-				}))
-			));
+		})).toMatchSnapshot();
 	});
 });

--- a/src/reducers/node.reducer.js
+++ b/src/reducers/node.reducer.js
@@ -1,5 +1,8 @@
 import { Map } from 'immutable';
 import invariant from 'invariant';
+import { removePort } from '../actions/port.actions';
+import portReducer from './port.reducer';
+import { outPort, inPort } from '../selectors/portSelectors';
 
 import {
 	FLOWDESIGNER_NODE_ADD,
@@ -62,7 +65,14 @@ const nodeReducer = (state = defaultState, action) => {
 		if (!state.getIn(['nodes', action.nodeId])) {
 			invariant(false, `Can not remove node ${action.nodeId} since it doesn't exist`);
 		}
-		return state.deleteIn(['nodes', action.nodeId])
+		return inPort(state, action.nodeId).reduce(
+			(cumulativeState, port, key) => portReducer(cumulativeState, removePort(key)),
+			outPort(state, action.nodeId).reduce(
+				(cumulativeState, port, key) => portReducer(cumulativeState, removePort(key)),
+				state
+			)
+		)
+		.deleteIn(['nodes', action.nodeId])
 		.deleteIn(['out', action.nodeId])
 		.deleteIn(['in', action.nodeId])
 		.deleteIn(['sucs', action.nodeId])

--- a/src/reducers/node.reducer.js
+++ b/src/reducers/node.reducer.js
@@ -17,50 +17,58 @@ import {
 const defaultState = new Map();
 const nodeReducer = (state = defaultState, action) => {
 	switch (action.type) {
-		case FLOWDESIGNER_NODE_ADD:
-			if (state.getIn(['nodes', action.nodeId])) {
-				invariant(false, `Can not create node ${action.nodeId} since it does already exist`);
-			}
-			return state.setIn(['nodes', action.nodeId], new NodeRecord({
-				id: action.nodeId,
-				position: new PositionRecord(action.nodePosition),
-				nodeSize: new SizeRecord(action.nodeSize),
-				nodeType: action.nodeType,
-				attributes: new Map(action.attributes),
-			}));
-		case FLOWDESIGNER_NODE_MOVE || FLOWDESIGNER_NODE_MOVE_END:
-			if (!state.getIn('nodes', action.nodeId)) {
-				invariant(false, `Can't move node ${action.nodeId} since it doesn't exist`);
-			}
-			return state.setIn(
+	case FLOWDESIGNER_NODE_ADD:
+		if (state.getIn(['nodes', action.nodeId])) {
+			invariant(false, `Can not create node ${action.nodeId} since it does already exist`);
+		}
+		return state.setIn(['nodes', action.nodeId], new NodeRecord({
+			id: action.nodeId,
+			position: new PositionRecord(action.nodePosition),
+			nodeSize: new SizeRecord(action.nodeSize),
+			nodeType: action.nodeType,
+			attributes: new Map(action.attributes),
+		}))
+		.setIn(['out', action.nodeId], new Map())
+		.setIn(['in', action.nodeId], new Map())
+		.setIn(['sucs', action.nodeId], new Map())
+		.setIn(['preds', action.nodeId], new Map());
+	case FLOWDESIGNER_NODE_MOVE || FLOWDESIGNER_NODE_MOVE_END:
+		if (!state.getIn('nodes', action.nodeId)) {
+			invariant(false, `Can't move node ${action.nodeId} since it doesn't exist`);
+		}
+		return state.setIn(
 				['nodes', action.nodeId, 'position'],
 				new PositionRecord(action.nodePosition)
 			);
-		case FLOWDESIGNER_NODE_SET_SIZE:
-			if (!state.getIn(['nodes', action.nodeId])) {
-				invariant(false, `Can't set size on node ${action.nodeId} since it doesn't exist`);
-			}
-			return state.setIn(
+	case FLOWDESIGNER_NODE_SET_SIZE:
+		if (!state.getIn(['nodes', action.nodeId])) {
+			invariant(false, `Can't set size on node ${action.nodeId} since it doesn't exist`);
+		}
+		return state.setIn(
 				['nodes', action.nodeId, 'nodeSize'],
 				new SizeRecord(action.nodeSize)
 			);
-		case FLOWDESIGNER_NODE_SET_ATTR:
-			if (!state.getIn(['nodes', action.nodeId])) {
-				invariant(false, `Can't set an attribute on non existing node ${action.nodeId}`);
-			}
-			return state.mergeIn(['nodes', action.nodeId, 'attributes'], new Map(action.attributes));
-		case FLOWDESIGNER_NODE_REMOVE_ATTR:
-			if (!state.getIn(['nodes', action.nodeId])) {
-				invariant(false, `Can't remove an attribute on non existing node ${action.nodeId}`);
-			}
-			return state.deleteIn(['nodes', action.nodeId, 'attributes', action.attributesKey]);
-		case FLOWDESIGNER_NODE_REMOVE:
-			if (!state.getIn(['nodes', action.nodeId])) {
-				invariant(false, `Can not remove node ${action.nodeId} since it doesn't exist`);
-			}
-			return state.deleteIn(['nodes', action.nodeId]);
-		default:
-			return state;
+	case FLOWDESIGNER_NODE_SET_ATTR:
+		if (!state.getIn(['nodes', action.nodeId])) {
+			invariant(false, `Can't set an attribute on non existing node ${action.nodeId}`);
+		}
+		return state.mergeIn(['nodes', action.nodeId, 'attributes'], new Map(action.attributes));
+	case FLOWDESIGNER_NODE_REMOVE_ATTR:
+		if (!state.getIn(['nodes', action.nodeId])) {
+			invariant(false, `Can't remove an attribute on non existing node ${action.nodeId}`);
+		}
+		return state.deleteIn(['nodes', action.nodeId, 'attributes', action.attributesKey]);
+	case FLOWDESIGNER_NODE_REMOVE:
+		if (!state.getIn(['nodes', action.nodeId])) {
+			invariant(false, `Can not remove node ${action.nodeId} since it doesn't exist`);
+		}
+		return state.deleteIn(['nodes', action.nodeId])
+		.deleteIn(['out', action.nodeId])
+		.deleteIn(['in', action.nodeId])
+		.deleteIn(['sucs', action.nodeId])
+		.deleteIn(['preds', action.nodeId]);
+	default:
+		return state;
 	}
 };
 

--- a/src/reducers/node.reducer.test.js
+++ b/src/reducers/node.reducer.test.js
@@ -2,7 +2,7 @@ import { Map } from 'immutable';
 
 import { defaultState } from './flow.reducer';
 import nodeReducer from './node.reducer';
-import { NodeRecord, PositionRecord, SizeRecord } from '../constants/flowdesigner.model';
+import { NodeRecord, PositionRecord } from '../constants/flowdesigner.model';
 
 describe('Check node reducer', () => {
 	const initialState = defaultState.setIn(['nodes', 'id1'], new NodeRecord({

--- a/src/reducers/node.reducer.test.js
+++ b/src/reducers/node.reducer.test.js
@@ -1,10 +1,11 @@
 import { Map } from 'immutable';
 
+import { defaultState } from './flow.reducer';
 import nodeReducer from './node.reducer';
 import { NodeRecord, PositionRecord, SizeRecord } from '../constants/flowdesigner.model';
 
 describe('Check node reducer', () => {
-	const initialState = new Map().setIn(['nodes', 'id1'], new NodeRecord({
+	const initialState = defaultState.setIn(['nodes', 'id1'], new NodeRecord({
 		id: 'id1',
 		nodeType: 'type1',
 		position: new PositionRecord({ x: 10, y: 10 }),
@@ -17,7 +18,7 @@ describe('Check node reducer', () => {
 	}));
 
 	it('FLOWDESIGNER_NODE_ADD properly add a new node to the node collection', () => {
-		expect(nodeReducer(new Map(), {
+		expect(nodeReducer(defaultState, {
 			type: 'FLOWDESIGNER_NODE_ADD',
 			nodeId: 'id',
 			nodePosition: { x: 10, y: 10 },
@@ -25,7 +26,7 @@ describe('Check node reducer', () => {
 	});
 
 	it('FLOWDESIGNER_NODE_ADD add a new node to the node collection with the right type', () => {
-		expect(nodeReducer(new Map(), {
+		expect(nodeReducer(defaultState, {
 			type: 'FLOWDESIGNER_NODE_ADD',
 			nodeId: 'id',
 			nodeType: 'MY_NODE_TYPE',
@@ -39,17 +40,7 @@ describe('Check node reducer', () => {
 			type: 'FLOWDESIGNER_NODE_MOVE',
 			nodeId: 'id2',
 			nodePosition: { x: 50, y: 50 },
-		})).toEqual(new Map().setIn(['nodes', 'id1'], new NodeRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'type1',
-			attributes: new Map({ selected: true }),
-		})).setIn(['nodes', 'id2'], new NodeRecord({
-			id: 'id2',
-			position: new PositionRecord({ x: 50, y: 50 }),
-			nodeType: 'type2',
-			attributes: new Map({ selected: false }),
-		})));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_NODE_SET_SIZE update node size property', () => {
@@ -57,18 +48,7 @@ describe('Check node reducer', () => {
 			type: 'FLOWDESIGNER_NODE_SET_SIZE',
 			nodeId: 'id1',
 			nodeSize: { height: 200, width: 200 },
-		})).toEqual(new Map().setIn(['nodes', 'id1'], new NodeRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeSize: new SizeRecord({ height: 200, width: 200 }),
-			nodeType: 'type1',
-			attributes: new Map({ selected: true }),
-		})).setIn(['nodes', 'id2'], new NodeRecord({
-			id: 'id2',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'type2',
-			attributes: new Map({ selected: false }),
-		})));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_NODE_SET_ATTR should add attribute to node attribute map', () => {
@@ -76,17 +56,7 @@ describe('Check node reducer', () => {
 			type: 'FLOWDESIGNER_NODE_SET_ATTR',
 			nodeId: 'id1',
 			attributes: { selected: false },
-		})).toEqual(new Map().setIn(['nodes', 'id1'], new NodeRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'type1',
-			attributes: new Map({ selected: false }),
-		})).setIn(['nodes', 'id2'], new NodeRecord({
-			id: 'id2',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'type2',
-			attributes: new Map({ selected: false }),
-		})));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_NODE_REMOVE_ATTR should add attribute to node attribute map', () => {
@@ -94,17 +64,7 @@ describe('Check node reducer', () => {
 			type: 'FLOWDESIGNER_NODE_REMOVE_ATTR',
 			nodeId: 'id1',
 			attributesKey: 'selected',
-		})).toEqual(new Map().setIn(['nodes', 'id1'], new NodeRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'type1',
-			attributes: new Map(),
-		})).setIn(['nodes', 'id2'], new NodeRecord({
-			id: 'id2',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'type2',
-			attributes: new Map({ selected: false }),
-		})));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_NODE_REMOVE should remove node from node collection', () => {

--- a/src/reducers/node.reducer.test.js
+++ b/src/reducers/node.reducer.test.js
@@ -21,13 +21,7 @@ describe('Check node reducer', () => {
 			type: 'FLOWDESIGNER_NODE_ADD',
 			nodeId: 'id',
 			nodePosition: { x: 10, y: 10 },
-		})).toEqual(new Map().setIn(['nodes', 'id'], new NodeRecord({
-			id: 'id',
-			nodeType: undefined,
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeSize: new SizeRecord({ width: undefined, height: undefined }),
-			attributes: new Map(),
-		})));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_NODE_ADD add a new node to the node collection with the right type', () => {
@@ -37,13 +31,7 @@ describe('Check node reducer', () => {
 			nodeType: 'MY_NODE_TYPE',
 			nodePosition: { x: 10, y: 10 },
 			attributes: { name: 'test' },
-		})).toEqual(new Map().setIn(['nodes', 'id'], new NodeRecord({
-			id: 'id',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'MY_NODE_TYPE',
-			nodeSize: new SizeRecord({ width: undefined, height: undefined }),
-			attributes: new Map().set('name', 'test'),
-		})));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_NODE_MOVE update node position', () => {
@@ -123,11 +111,6 @@ describe('Check node reducer', () => {
 		expect(nodeReducer(initialState, {
 			type: 'FLOWDESIGNER_NODE_REMOVE',
 			nodeId: 'id1',
-		})).toEqual(new Map().setIn(['nodes', 'id2'], new NodeRecord({
-			id: 'id2',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			nodeType: 'type2',
-			attributes: new Map({ selected: false }),
-		})));
+		})).toMatchSnapshot();
 	});
 });

--- a/src/reducers/port.reducer.js
+++ b/src/reducers/port.reducer.js
@@ -3,6 +3,9 @@ import { Map, OrderedMap } from 'immutable';
 import {
 	PortRecord,
 } from '../constants/flowdesigner.model';
+import { removeLink } from '../actions/link.actions';
+import linkReducer from './link.reducer';
+import { portOutLink, portInLink } from '../selectors/linkSelectors';
 
 import {
 	FLOWDESIGNER_PORT_ADD,
@@ -76,15 +79,16 @@ export default function portReducer(state = defaultState, action) {
 			invariant(false,
 					`Can not remove port ${action.portId} since it doesn't exist`);
 		}
-		return state.deleteIn(['ports', action.portId])
+		return portInLink(state, action.portId).reduce(
+				(cumulativeState, link) => linkReducer(cumulativeState, removeLink(link.id)),
+				portOutLink(state, action.portId).reduce(
+					(cumulativeState, link) => linkReducer(cumulativeState, removeLink(link.id)),
+					state
+				)
+			)
+			.deleteIn(['ports', action.portId])
 			.deleteIn(['out', state.getIn(['ports', action.portId]).nodeId, action.portId])
-			.deleteIn(['in', state.getIn(['ports', action.portId]).nodeId, action.portId])
-			// TODO: SUCESSOR, PREDECESSOR CLEANING
-			.deleteIn([
-				'sucs',
-				state.getIn(['ports', state.getaction.portId]).nodeId,
-				state.getIn(['ports', action.portId]).nodeId,
-			]);
+			.deleteIn(['in', state.getIn(['ports', action.portId]).nodeId, action.portId]);
 	default:
 		return state;
 	}

--- a/src/reducers/port.reducer.js
+++ b/src/reducers/port.reducer.js
@@ -14,34 +14,43 @@ import {
 
 const defaultState = new OrderedMap();
 
-const setPort = (state, port) => (
-	state.setIn(['ports', port.id], new PortRecord({
+const setPort = (state, port) => {
+	const newState = state.setIn(['ports', port.id], new PortRecord({
 		id: port.id,
 		nodeId: port.nodeId,
 		portType: port.portType,
 		attributes: new Map(port.attributes),
-	}))
-);
+	}));
+	if (port.attributes.get('type') === 'EMITTER') {
+		return newState.setIn(['out', port.nodeId, port.id], new Map());
+	} else if (port.attributes.get('type') === 'SINK') {
+		return newState.setIn(['in', port.nodeId, port.id], new Map());
+	}
+	invariant(false,
+		`Can't set a new port ${port.id} if its attribute.type !== EMITTER || SINK,
+		given ${port.attributes.get('type')}`);
+	return state;
+};
 
 export default function portReducer(state = defaultState, action) {
 	switch (action.type) {
-		case FLOWDESIGNER_PORT_ADD:
-			if (!state.getIn(['nodes', action.nodeId])) {
-				invariant(false,
+	case FLOWDESIGNER_PORT_ADD:
+		if (!state.getIn(['nodes', action.nodeId])) {
+			invariant(false,
 					`Can't set a new port ${action.portId} on non existing node ${action.nodeId}`);
-			}
-			return setPort(state, {
-				id: action.portId,
-				nodeId: action.nodeId,
-				portType: action.portType,
-				attributes: new Map(action.attributes),
-			});
-		case FLOWDESIGNER_PORT_ADDS:
-			if (!state.getIn(['nodes', action.nodeId])) {
-				invariant(false,
+		}
+		return setPort(state, {
+			id: action.portId,
+			nodeId: action.nodeId,
+			portType: action.portType,
+			attributes: new Map(action.attributes),
+		});
+	case FLOWDESIGNER_PORT_ADDS:
+		if (!state.getIn(['nodes', action.nodeId])) {
+			invariant(false,
 					`Can't set a new port ${action.portId} on non existing node ${action.nodeId}`);
-			}
-			return action.ports.reduce(
+		}
+		return action.ports.reduce(
 				(cumulatedState, port) =>
 					setPort(cumulatedState, {
 						id: port.portId,
@@ -50,25 +59,33 @@ export default function portReducer(state = defaultState, action) {
 						attributes: new Map(port.attributes),
 					})
 				, state);
-		case FLOWDESIGNER_PORT_SET_ATTR:
-			if (!state.getIn(['ports', action.portId])) {
-				invariant(false,
+	case FLOWDESIGNER_PORT_SET_ATTR:
+		if (!state.getIn(['ports', action.portId])) {
+			invariant(false,
 					`Can't set an attribute on non existing port ${action.portId}`);
-			}
-			return state.mergeIn(['ports', action.portId, 'attributes'], new Map(action.attributes));
-		case FLOWDESIGNER_PORT_REMOVE_ATTR:
-			if (!state.getIn(['ports', action.portId])) {
-				invariant(false,
+		}
+		return state.mergeIn(['ports', action.portId, 'attributes'], new Map(action.attributes));
+	case FLOWDESIGNER_PORT_REMOVE_ATTR:
+		if (!state.getIn(['ports', action.portId])) {
+			invariant(false,
 					`Can't remove an attribute on non existing port ${action.portId}`);
-			}
-			return state.deleteIn(['ports', action.portId, 'attributes', action.attributesKey]);
-		case FLOWDESIGNER_PORT_REMOVE:
-			if (!state.getIn(['ports', action.portId])) {
-				invariant(false,
+		}
+		return state.deleteIn(['ports', action.portId, 'attributes', action.attributesKey]);
+	case FLOWDESIGNER_PORT_REMOVE:
+		if (!state.getIn(['ports', action.portId])) {
+			invariant(false,
 					`Can not remove port ${action.portId} since it doesn't exist`);
-			}
-			return state.deleteIn(['ports', action.portId]);
-		default:
-			return state;
+		}
+		return state.deleteIn(['ports', action.portId])
+			.deleteIn(['out', state.getIn(['ports', action.portId]).nodeId, action.portId])
+			.deleteIn(['in', state.getIn(['ports', action.portId]).nodeId, action.portId])
+			// TODO: SUCESSOR, PREDECESSOR CLEANING
+			.deleteIn([
+				'sucs',
+				state.getIn(['ports', state.getaction.portId]).nodeId,
+				state.getIn(['ports', action.portId]).nodeId,
+			]);
+	default:
+		return state;
 	}
 }

--- a/src/reducers/port.reducer.test.js
+++ b/src/reducers/port.reducer.test.js
@@ -1,10 +1,11 @@
 import { Map, OrderedMap } from 'immutable';
 
+import { defaultState } from './flow.reducer';
 import portReducer from './port.reducer';
 import { PortRecord, PositionRecord } from '../constants/flowdesigner.model';
 
 describe('Check port reducer', () => {
-	const initialState = new Map().set('ports', new OrderedMap()
+	const initialState = defaultState.set('ports', new OrderedMap()
 		.set('id1', new PortRecord({
 			id: 'id1',
 			position: new PositionRecord({ x: 10, y: 10 }),

--- a/src/reducers/port.reducer.test.js
+++ b/src/reducers/port.reducer.test.js
@@ -18,7 +18,7 @@ describe('Check port reducer', () => {
 			id: 'id3',
 			position: new PositionRecord({ x: 10, y: 10 }),
 		})))
-		.set('nodes', new Map().set('nodeId', new Map()));
+		.set('nodes', new Map().set('nodeId', new Map())).set('links', new Map());
 
 	it('FLOWDESIGNER_PORT_ADD properly add the port to the port OrderedMap', () => {
 		expect(portReducer(initialState, {
@@ -26,27 +26,8 @@ describe('Check port reducer', () => {
 			nodeId: 'nodeId',
 			portId: 'portId',
 			portType: 'portType',
-			attributes: { clicked: true },
-		})).toEqual(new Map().set('ports', new OrderedMap().set('id1', new PortRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			attributes: new Map().set('attr', 'attr'),
-		}))
-			.set('id2', new PortRecord({
-				id: 'id2',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			}))
-			.set('id3', new PortRecord({
-				id: 'id3',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			}))
-			.set('portId', new PortRecord({
-				id: 'portId',
-				nodeId: 'nodeId',
-				portType: 'portType',
-				attributes: new Map({ clicked: true }),
-			})))
-			.set('nodes', new Map().set('nodeId', new Map())));
+			attributes: { clicked: true, type: 'EMITTER' },
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_PORT_ADDS to add multiple ports to port collection', () => {
@@ -56,38 +37,13 @@ describe('Check port reducer', () => {
 			ports: [{
 				portId: 'portId1',
 				portType: 'portType',
+				attributes: { type: 'EMITTER' },
 			}, {
 				portId: 'portId2',
 				portType: 'portType',
+				attributes: { type: 'SINK' },
 			}],
-		})).toEqual(new Map().set('ports', new OrderedMap().set('id1', new PortRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			attributes: new Map().set('attr', 'attr'),
-		}))
-			.set('id2', new PortRecord({
-				id: 'id2',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			}))
-			.set('id3', new PortRecord({
-				id: 'id3',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			}))
-			.set('portId1', new PortRecord({
-				id: 'portId1',
-				nodeId: 'nodeId',
-				position: undefined,
-				portType: 'portType',
-				attributes: new Map(),
-			}))
-			.set('portId2', new PortRecord({
-				id: 'portId2',
-				nodeId: 'nodeId',
-				position: undefined,
-				portType: 'portType',
-				attributes: new Map(),
-			})))
-			.set('nodes', new Map().set('nodeId', new Map())));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_PORT_SET_ATTR to merge a new attributes in attribute collection', () => {
@@ -95,20 +51,7 @@ describe('Check port reducer', () => {
 			type: 'FLOWDESIGNER_PORT_SET_ATTR',
 			portId: 'id1',
 			attributes: { selected: true },
-		})).toEqual(new Map().set('ports', new OrderedMap().set('id1', new PortRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			attributes: new Map().set('attr', 'attr').set('selected', true),
-		}))
-			.set('id2', new PortRecord({
-				id: 'id2',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			}))
-			.set('id3', new PortRecord({
-				id: 'id3',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			})))
-			.set('nodes', new Map().set('nodeId', new Map())));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_PORT_REMOVE_ATTR to remove attr from attr map', () => {
@@ -116,35 +59,13 @@ describe('Check port reducer', () => {
 			type: 'FLOWDESIGNER_PORT_REMOVE_ATTR',
 			portId: 'id1',
 			attributesKey: 'attr',
-		})).toEqual(new Map().set('ports', new OrderedMap().set('id1', new PortRecord({
-			id: 'id1',
-			position: new PositionRecord({ x: 10, y: 10 }),
-			attributes: new Map(),
-		}))
-			.set('id2', new PortRecord({
-				id: 'id2',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			}))
-			.set('id3', new PortRecord({
-				id: 'id3',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			})))
-			.set('nodes', new Map().set('nodeId', new Map())));
+		})).toMatchSnapshot();
 	});
 
 	it('FLOWDESIGNER_PORT_REMOVE should remove port from ports collection', () => {
 		expect(portReducer(initialState, {
 			type: 'FLOWDESIGNER_PORT_REMOVE',
 			portId: 'id1',
-		})).toEqual(new Map().set('ports', new OrderedMap()
-			.set('id2', new PortRecord({
-				id: 'id2',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			}))
-			.set('id3', new PortRecord({
-				id: 'id3',
-				position: new PositionRecord({ x: 10, y: 10 }),
-			})))
-			.set('nodes', new Map().set('nodeId', new Map())));
+		})).toMatchSnapshot();
 	});
 });

--- a/src/selectors/linkSelectors.js
+++ b/src/selectors/linkSelectors.js
@@ -20,7 +20,7 @@ export const getDetachedLinks = createSelector(
  * @return {Link}
  */
 export function portOutLink(state, portId) {
-	return state.get('links').filter(link => link.sourceId === portId);
+	return state.get('links').filter(link => link.sourceId === portId) || new Map();
 }
 
 /**
@@ -29,7 +29,7 @@ export function portOutLink(state, portId) {
  * @return {Link}
  */
 export function portInLink(state, portId) {
-	return state.get('links').filter(link => link.targetId === portId);
+	return state.get('links').filter(link => link.targetId === portId) || new Map();
 }
 
 /**

--- a/src/selectors/linkSelectors.js
+++ b/src/selectors/linkSelectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { Map } from 'immutable';
 
 const getPorts = state => state.get('ports');
 const getLinks = state => state.get('links');
@@ -12,5 +13,45 @@ export const getDetachedLinks = createSelector(
 		)
 	)
 );
+
+/**
+ * get outgoing link from a port
+ *
+ * @return {Link}
+ */
+export function portOutLink(state, portId) {
+	return state.get('links').filter(link => link.sourceId === portId);
+}
+
+/**
+ * get ingoing link from a port
+ *
+ * @return {Link}
+ */
+export function portInLink(state, portId) {
+	return state.get('links').filter(link => link.targetId === portId);
+}
+
+/**
+ * get outgoing linkId from a node
+ *
+ * @return number
+ */
+export function outLink(state, nodeId) {
+	return state.getIn(['out', nodeId]).reduce((reduction, port) =>
+		reduction.merge(port)
+	, new Map());
+}
+
+/**
+ * get inGoing linkId from a node
+ *
+ * @return number
+ */
+export function inLink(state, nodeId) {
+	return state.getIn(['in', nodeId]).reduce((reduction, port) =>
+		reduction.merge(port)
+	, new Map());
+}
 
 export default getDetachedLinks;

--- a/src/selectors/nodeSelectors.js
+++ b/src/selectors/nodeSelectors.js
@@ -4,11 +4,14 @@ import { Map } from 'immutable';
 const getNodes = state => state.get('nodes');
 const getPorts = state => state.get('ports');
 
+/**
+ * TO BE DELETED
+ */
 export const getNodesWithPorts = createSelector(
 	[getNodes, getPorts],
 	(nodes, ports) => {
 		let nodesWithPorts = new Map();
-		nodes.forEach(node => {
+		nodes.forEach((node) => {
 			nodesWithPorts = nodesWithPorts.set(
 				node.id, new Map({ node, ports: ports.filter(port => port.nodeId === node.id) })
 			);

--- a/src/selectors/portSelectors.js
+++ b/src/selectors/portSelectors.js
@@ -6,14 +6,28 @@ const getPorts = state => state.get('ports');
 const getLinks = state => state.get('links');
 
 /**
+ * return a list of outgoing port for this node
+ */
+export function outPort(state, nodeId) {
+	return state.getIn(['out', nodeId]);
+}
+
+/**
+ * return a list of ingoing port for this node
+ */
+export function inPort(state, nodeId) {
+	return state.getIn(['in', nodeId]);
+}
+
+/**
  * Create and return function who will return all ports for a specific node
  * @return {getPortsForNode}
  */
 export const getPortsForNode = createSelector(
-  getPorts,
-  ports => memoize(
-    nodeId => ports.filter(port => port.nodeId === nodeId)
-  )
+	getPorts,
+	ports => memoize(
+		nodeId => ports.filter(port => port.nodeId === nodeId)
+	)
 );
 
 
@@ -23,10 +37,10 @@ export const getPortsForNode = createSelector(
  * @return Map
  */
 export const getEmitterPorts = createSelector(
-  getPorts,
-  ports => (
-    ports.filter(port => port.attributes.get('type') === 'EMITTER')
-  )
+	getPorts,
+	ports => (
+		ports.filter(port => port.attributes.get('type') === 'EMITTER')
+	)
 );
 
 /**
@@ -35,30 +49,30 @@ export const getEmitterPorts = createSelector(
  * @return Map
  */
 export const getSinkPorts = createSelector(
-  getPorts,
-  ports => (
-    ports.filter(port => port.attributes.get('type') === 'SINK')
-  )
+	getPorts,
+	ports => (
+		ports.filter(port => port.attributes.get('type') === 'SINK')
+	)
 );
 
 /**
  * Create and return function who will return all Emitter ports for a specific node
  */
 export const getEmitterPortsForNode = createSelector(
-  getEmitterPorts,
-  ports => (
-    nodeId => ports.filter(port => port.nodeId === nodeId)
-  )
+	getEmitterPorts,
+	ports => (
+		nodeId => ports.filter(port => port.nodeId === nodeId)
+	)
 );
 
 /**
  * Create and return function who will return all Sink ports for a specific node
  */
 export const getSinkPortsForNode = createSelector(
-  getSinkPorts,
-  ports => (
-    nodeId => ports.filter(port => port.nodeId === nodeId)
-  )
+	getSinkPorts,
+	ports => (
+		nodeId => ports.filter(port => port.nodeId === nodeId)
+	)
 );
 
 /**
@@ -68,14 +82,14 @@ export const getSinkPortsForNode = createSelector(
  * @return Map
  */
 export const getFreeSinkPorts = createSelector(
-  [getSinkPorts, getLinks],
-  (sinkPorts, links) => (
-    sinkPorts.filter(sinkPort => (
-      !links.find(link => (
-        link.targetId === sinkPort.id
-      ))
-    ))
-  )
+	[getSinkPorts, getLinks],
+	(sinkPorts, links) => (
+		sinkPorts.filter(sinkPort => (
+			!links.find(link => (
+				link.targetId === sinkPort.id
+			))
+		))
+	)
 );
 
 /**
@@ -85,14 +99,14 @@ export const getFreeSinkPorts = createSelector(
  * @return Map
  */
 export const getFreeEmitterPorts = createSelector(
-  [getEmitterPorts, getLinks],
-  (emitterPorts, links) => (
-    emitterPorts.filter(emitterPort =>
-      !links.find(link => (
-        link.sourceId === emitterPort.id
-      ))
-    )
-  )
+	[getEmitterPorts, getLinks],
+	(emitterPorts, links) => (
+		emitterPorts.filter(emitterPort =>
+			!links.find(link => (
+				link.sourceId === emitterPort.id
+			))
+		)
+	)
 );
 
 /**
@@ -102,19 +116,19 @@ export const getFreeEmitterPorts = createSelector(
  * @return Map
  */
 export const getActionKeyedPorts = createSelector(
-  [getFreeSinkPorts],
-  freeSinkPorts => (
-    freeSinkPorts.filter(sinkPort => sinkPort.accessKey)
-  )
+	[getFreeSinkPorts],
+	freeSinkPorts => (
+		freeSinkPorts.filter(sinkPort => sinkPort.accessKey)
+	)
 );
 
 export const getDetachedPorts = createSelector(
-  [getPorts, getNodes],
-  (ports, nodes) => (
-    ports.filter(
-      port => !nodes.find(
-        node => node.id === port.nodeId
-      )
-    )
-  )
+	[getPorts, getNodes],
+	(ports, nodes) => (
+		ports.filter(
+			port => !nodes.find(
+				node => node.id === port.nodeId
+			)
+		)
+	)
 );

--- a/src/selectors/portSelectors.js
+++ b/src/selectors/portSelectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import memoize from 'lodash/memoize';
+import { Map } from 'immutable';
 
 const getNodes = state => state.get('nodes');
 const getPorts = state => state.get('ports');
@@ -9,14 +10,14 @@ const getLinks = state => state.get('links');
  * return a list of outgoing port for this node
  */
 export function outPort(state, nodeId) {
-	return state.getIn(['out', nodeId]);
+	return state.getIn(['out', nodeId]) || new Map();
 }
 
 /**
  * return a list of ingoing port for this node
  */
 export function inPort(state, nodeId) {
-	return state.getIn(['in', nodeId]);
+	return state.getIn(['in', nodeId]) || new Map();
 }
 
 /**

--- a/src/selectors/portSelectors.test.js
+++ b/src/selectors/portSelectors.test.js
@@ -1,5 +1,6 @@
 import { Map } from 'immutable';
 import * as Selectors from './portSelectors';
+import { defaultState } from '../reducers/flow.reducer';
 import {
 	LinkRecord,
 	PortRecord,
@@ -26,7 +27,7 @@ describe('Testing dataflow selectors', () => {
 		nodeId: 'nodeId2',
 		attributes: new Map({ type: 'EMITTER' }),
 	});
-	const givenState = new Map().set('links', new Map().set('id1', new LinkRecord({
+	const givenState = defaultState.set('links', new Map().set('id1', new LinkRecord({
 		id: 'id1',
 		source: 'id1',
 		target: 'id2',
@@ -46,9 +47,9 @@ describe('Testing dataflow selectors', () => {
 
 	it(`getEmitterPortsForNode return a function
 	  wich can be used to retribe emitterPorts form specific node`, () => {
-			const expectedPortMap = new Map().set('id2', port2);
-			expect(Selectors.getEmitterPortsForNode(givenState)('nodeId1')).toEqual(expectedPortMap);
-		});
+		const expectedPortMap = new Map().set('id2', port2);
+		expect(Selectors.getEmitterPortsForNode(givenState)('nodeId1')).toEqual(expectedPortMap);
+	});
 
 	it('getSinkPorts return a map of Sink ports ', () => {
 		const expectedPortsMap = new Map().set('id1', port1).set('id3', port3);
@@ -57,7 +58,7 @@ describe('Testing dataflow selectors', () => {
 
 	it(`getSinkPortsForNode return a function
 	  wich can be used to retribe emitterPorts form specific node`, () => {
-			const expectedPortMap = new Map().set('id2', port2);
-			expect(Selectors.getEmitterPortsForNode(givenState)('nodeId1')).toEqual(expectedPortMap);
-		});
+		const expectedPortMap = new Map().set('id2', port2);
+		expect(Selectors.getEmitterPortsForNode(givenState)('nodeId1')).toEqual(expectedPortMap);
+	});
 });


### PR DESCRIPTION
denormalize some part of the graph at mutation time : 
- ```in``` [nodeId][portId][linkId] to know wich link are targeting a node
- ```out``` [nodeId][portId][linkId] to know wich link are leaving a node
- ```preds``` [nodeId][nodeId] to know wich node are direct children of a node
- ```sucs``` [nodeId][nodeId] to know wich node are direct parents of a node

add some fragment data selectors using this new data

changed the way cascade deletion work.
Before : 
Deleting node -> Deleting ports ->  Deleting links
Now:
Ask deleting node -> Ask deleting ports ->  Deleting links -> Deleting ports -> Deleting node