### PR TITLE
fix(links): add preds and sucs update on link transformations

### DIFF
--- a/src/reducers/__snapshots__/link.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/link.reducer.test.js.snap
@@ -370,7 +370,11 @@ Object {
       "position": undefined,
     },
   },
-  "preds": Object {},
+  "preds": Object {
+    "id2": Object {
+      "id1": undefined,
+    },
+  },
   "sucs": Object {},
   "transform": Object {
     "k": 1,
@@ -449,7 +453,11 @@ Object {
     },
   },
   "preds": Object {},
-  "sucs": Object {},
+  "sucs": Object {
+    "id1": Object {
+      "id2": undefined,
+    },
+  },
   "transform": Object {
     "k": 1,
     "x": 0,

--- a/src/reducers/link.reducer.js
+++ b/src/reducers/link.reducer.js
@@ -59,7 +59,9 @@ export default function linkReducer(state = defaultState, action) {
 		}
 		return state.setIn(['links', action.linkId, 'targetId'], action.targetId)
 		.deleteIn(['in', state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId, state.getIn(['links', action.linkId]).targetId, action.linkId])
-		.setIn(['in', state.getIn(['ports', action.targetId]).nodeId, action.targetId, action.linkId], action.linkId);
+		.setIn(['in', state.getIn(['ports', action.targetId]).nodeId, action.targetId, action.linkId], action.linkId)
+		.deleteIn(['sucs', state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId, state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId])
+		.setIn(['sucs', state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId, state.getIn(['ports', action.targetId]).nodeId]);
 	case FLOWDESIGNER_LINK_SET_SOURCE:
 		if (!state.getIn(['links', action.linkId])) {
 			invariant(
@@ -75,7 +77,9 @@ export default function linkReducer(state = defaultState, action) {
 		}
 		return state.setIn(['links', action.linkId, 'sourceId'], action.sourceId)
 		.deleteIn(['out', state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId, state.getIn(['links', action.linkId]).sourceId, action.linkId])
-		.setIn(['out', state.getIn(['ports', action.sourceId]).nodeId, action.sourceId, action.linkId], action.linkId);
+		.setIn(['out', state.getIn(['ports', action.sourceId]).nodeId, action.sourceId, action.linkId], action.linkId)
+		.deleteIn(['preds', state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId, state.getIn(['ports', state.getIn(['links', action.linkId]).sourceId]).nodeId])
+		.setIn(['preds', state.getIn(['ports', state.getIn(['links', action.linkId]).targetId]).nodeId, state.getIn(['ports', action.sourceId]).nodeId]);
 	case FLOWDESIGNER_LINK_REMOVE:
 		if (!state.getIn(['links', action.linkId])) {
 			invariant(


### PR DESCRIPTION
preds and sucs maps are not updated properly when the link is set to a new source or target